### PR TITLE
HOME-134 - Closing connections to clients doesn't work

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -70,6 +70,9 @@ void handleIncomingMsg(int incomingBytes) {
   else if (cmd == "CMDWHO") {
     softSerial.print("[1:agent]");
   }
+  else if (strcmp(cmd, "CMDDIS") == 0) {
+    softSerial.print("[0:disconnect]");
+  }  
 }
 
 void printDataPackage(float temperature, bool motion, bool gas, float sound) {


### PR DESCRIPTION
**Business justification:** HOME-134 - Closing connections to clients doesn't work

**Description:** When user was connected to the device via smarthome-cli and killed the connection from the CLI point of view, hardware was still 'thinking' it was connected. This PR creates a command that can be sent to container in channel 0 to close the connection.

**Related PRs:**
* https://github.com/smart-evolution/smart-home-uc/pull/5
* https://github.com/smart-evolution/smarthome-cli/pull/10
* https://github.com/smart-evolution/smarthome/pull/61
* https://github.com/smart-evolution/smart-home-agent-esp8266/pull/5